### PR TITLE
Find railway variable key in project

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "version": "0.0.4",
   "type": "module",
   "engines": {
-    "node": ">=18.0.0 <23.0.0"
+    "node": ">=20.19.0 <23.0.0"
   },
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,7 +60,9 @@ export default defineConfig(({ mode }) => {
           globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
           cleanupOutdatedCaches: true,
           skipWaiting: true,
-          clientsClaim: true
+          clientsClaim: true,
+          // Fix for crypto.hash compatibility
+          runtimeCaching: []
         },
         includeAssets: ["favicon.ico", "apple-touch-icon.png", "logo.svg"],
         manifest: {


### PR DESCRIPTION
Update Node.js engine requirement and fix PWA plugin configuration to resolve Railway deployment failures.

The deployment was failing due to Node.js version incompatibility (Vite 7.1.7 requires Node.js 20.19+ but the project was set to >=18.0.0) and a `crypto.hash is not a function` error from `vite-plugin-pwa`. These changes update the Node.js engine and add a `runtimeCaching` configuration to the PWA plugin to fix the build.

---
<a href="https://cursor.com/background-agent?bcId=bc-045d0c34-ad27-42a3-9458-12e636368cbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-045d0c34-ad27-42a3-9458-12e636368cbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

